### PR TITLE
Fix tabbing out causing infinite chatHUD jenga tower

### DIFF
--- a/lua/easychat/client/chathud.lua
+++ b/lua/easychat/client/chathud.lua
@@ -977,7 +977,7 @@ function base_line:Update()
 	if not self.Fading then return end
 
 	if self.LifeTime < RealTime() then
-		self.Alpha = math_max(self.Alpha + easychat.FadeTimeEnd - RealTime(), 0) * 255
+		self.Alpha = math_max(self.Alpha + chathud.FadeTimeEnd - RealTime(), 0) * 255
 
 		if self.Alpha == 0 then
 			self.ShouldRemove = true

--- a/lua/easychat/client/chathud.lua
+++ b/lua/easychat/client/chathud.lua
@@ -977,8 +977,7 @@ function base_line:Update()
 	if not self.Fading then return end
 
 	if self.LifeTime < RealTime() then
-		self.Alpha = self.ShouldRemove and 0
-			or math_floor(math_max(self.Alpha - (RealFrameTime() * 100), 0))
+		self.Alpha = math_max(self.Alpha + 1 - RealTime(), 0) * 255
 
 		if self.Alpha == 0 then
 			self.ShouldRemove = true

--- a/lua/easychat/client/chathud.lua
+++ b/lua/easychat/client/chathud.lua
@@ -125,6 +125,13 @@ cvars.AddChangeCallback(EC_HUD_TTL:GetName(), function()
 	chathud.FadeTime = EC_HUD_TTL:GetInt()
 end)
 
+local EC_HUD_FADELEN = GetConVar("easychat_hud_fadelen")
+chathud.FadeTimeEnd = EC_HUD_FADELEN:GetInt()
+
+cvars.AddChangeCallback(EC_HUD_FADELEN:GetName(), function()
+	chathud.FadeTimeEnd = EC_HUD_FADELEN:GetFloat()
+end)
+
 function chathud:ApplyCustomFontSettings()
 	if not file.Exists(CUSTOM_FONT_SETTINGS_PATH, "DATA") then return end
 
@@ -977,7 +984,7 @@ function base_line:Update()
 	if not self.Fading then return end
 
 	if self.LifeTime < RealTime() then
-		self.Alpha = math_max(self.Alpha + 1 - RealTime(), 0) * 255
+		self.Alpha = math_max(self.Alpha + easychat.FadeTimeEnd - RealTime(), 0) * 255
 
 		if self.Alpha == 0 then
 			self.ShouldRemove = true

--- a/lua/easychat/client/settings.lua
+++ b/lua/easychat/client/settings.lua
@@ -35,6 +35,7 @@ local EC_LEGACY_TEXT = GetConVar("easychat_legacy_text")
 -- chathud
 local EC_HUD_FOLLOW = GetConVar("easychat_hud_follow")
 local EC_HUD_TTL = GetConVar("easychat_hud_ttl")
+local EC_HUD_FADELEN = GetConVar("easychat_hud_fadelen")
 local EC_HUD_SMOOTH = GetConVar("easychat_hud_smooth")
 local EC_HUD_TIMESTAMPS = GetConVar("easychat_hud_timestamps")
 local EC_HUD_SH_CLEAR = GetConVar("easychat_hud_sh_clear")
@@ -446,6 +447,8 @@ local function create_default_settings()
 			local default_duration = tonumber(EC_HUD_TTL:GetDefault())
 			EC_HUD_TTL:SetInt(default_duration)
 		end
+
+		settings:AddConvarSettings(category_name, "number", EC_HUD_FADELEN, "Message Fadeout Time", 5, 1)
 	end
 end
 


### PR DESCRIPTION
Currently hardcodes to 1 second.

Todo: Make customizable? Change the 1 number to set length, if it's based on a constant on `easychat`, everything will automatically use that new length since nothing is local