### PR TITLE
create a convar to force usage of CEF panels on linux build of gmod

### DIFF
--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -395,6 +395,7 @@ if CLIENT then
 	local EC_PEEK_COMPLETION = CreateConVar("easychat_peek_completion", "1", FCVAR_ARCHIVE, "Display a preview of the possible text completion")
 	local EC_LEGACY_ENTRY = CreateConVar("easychat_legacy_entry", "0", FCVAR_ARCHIVE, "Uses the legacy textbox entry")
 	local EC_LEGACY_TEXT = CreateConVar("easychat_legacy_text", "0", FCVAR_ARCHIVE, "Uses the legacy text output")
+	local EC_FORCE_ALLOW_CEF = CreateConVar("easychat_force_allow_cef", "0", FCVAR_ARCHIVE, "Allow usage of CEF features on linux systems")
 	local _ = CreateConVar("easychat_modern_text_history_limit", "-1", FCVAR_ARCHIVE, "Limits how many messages are shown in the modern chat output")
 	local _ = CreateConVar("easychat_non_qwerty", "0", FCVAR_ARCHIVE, "Lets you tell EasyChat that you keyboard layout is not qwerty")
 
@@ -550,6 +551,7 @@ if CLIENT then
 
 	-- TODO: Figure out how to check keyboard IME
 	function EasyChat.CanUseCEFFeatures()
+		if EC_FORCE_ALLOW_CEF:GetBool() then return true end
 		if not system.IsWindows() and not system.IsOSX() then return false end -- cef is awfully broken on linux / mac
 		if BRANCH == "x86-64" or BRANCH == "chromium" then return true end -- chromium also exists in x86 and on the chromium branch
 		return jit.arch == "x64" -- when x64 and chromium are finally pushed to stable


### PR DESCRIPTION
CEF text input works fine for people using [solsticegamestudios GModCEFCodecFix](https://github.com/solsticegamestudios/GModCEFCodecFix/), but easychat is hardcoded to not use CEF panels on the linux build of gmod, so i made a convar to skip that check.