### PR TITLE
Sanitize usage of Lua variables in JS code properly

### DIFF
--- a/lua/autorun/easychat_init.lua
+++ b/lua/autorun/easychat_init.lua
@@ -1,13 +1,3 @@
-if CLIENT then
-	-- fuck you rubat
-	function WORKING_JS_SAFE(str)
-		return str:JavascriptSafe()
-			:gsub("`", "")
-			:gsub("%$%s*{", "")
-			:gsub("[Rr][Uu][Nn][Ll][Uu][Aa]", "")
-	end
-end
-
 AddCSLuaFile("easychat/networking.lua")
 AddCSLuaFile("easychat/server_config.lua")
 AddCSLuaFile("easychat/migrations.lua")

--- a/lua/easychat/chathud.lua
+++ b/lua/easychat/chathud.lua
@@ -908,7 +908,7 @@ local image_part = {
 
 function image_part:Ctor(url)
 	local browser = vgui.Create("DHTML")
-	browser:SetAllowLua(true)
+	browser:SetAllowLua(false)
 	browser:SetSize(0, 0)
 	browser:SetPaintedManually(true)
 	browser:AddFunction("Img", "Size", function(w, h)

--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -96,13 +96,20 @@ function PANEL:Init()
 		local paste_menu = DermaMenu()
 		paste_menu:AddOption("Paste", function()
 			self:QueueJavascript([[{
-				let ev = new ClipboardEvent("paste");
+				const ev = new ClipboardEvent("paste");
 				TEXT_ENTRY.dispatchEvent(ev);
 			}]])
 		end)
 		paste_menu:AddSpacer()
 		paste_menu:AddOption("Cancel", function() paste_menu:Remove() end)
 		paste_menu:Open()
+	end)
+
+	self:AddInternalCallback("GetCurrentValue", function()
+		return self:GetText() or ""
+	end)
+	self:AddInternalCallback("GetPlaceholderText", function()
+		return self.PlaceholderText or ""
 	end)
 
 	self:AddInternalCallback("Debug", print)
@@ -273,8 +280,7 @@ function PANEL:SetText(text)
 
 	self.CurrentValue = text
 
-	local html_input = WORKING_JS_SAFE(text)
-	self:QueueJavascript(([[TEXT_ENTRY.value = `%s`;]]):format(html_input))
+	self:QueueJavascript([[TextEntryX.GetCurrentValue(x => TEXT_ENTRY.value = x);]])
 end
 
 function PANEL:SetValue(text)
@@ -296,13 +302,15 @@ function PANEL:SetTextColor(col)
 end
 
 function PANEL:SetPlaceholderText(text)
-	self:QueueJavascript(([[TEXT_ENTRY.placeholder = `%s`;]]):format(WORKING_JS_SAFE(text)))
+	self.PlaceholderText = text
+
+	self:QueueJavascript([[TextEntryX.GetPlaceholderText(x => TEXT_ENTRY.placeholder = x);]])
 end
 
 function PANEL:SetPlaceholderColor(col)
 	self.PlaceholderColor = col
 	self:QueueJavascript([[{
-		let style = document.createElement("style");
+		const style = document.createElement("style");
 		style.type = "text/css";
 		style.innerHTML = "#text-entry::placeholder { color: ]] .. color_to_css(col)  .. [[; }";
 		document.getElementsByTagName("head")[0].appendChild(style);


### PR DESCRIPTION
Disabled `SetAllowLua` since it only causes trouble

I don't know if this is any slower but it seems to work perfectly fine, found out about a new way to use [`DHTML.AddFunction`](https://wiki.facepunch.com/gmod/DHTML:AddFunction) with this, lol
You can pass a JS callback as the last argument of an `AddFunction` function and use the return values of the Lua function called as its arguments

I hope I haven't missed anything, really