### PR TITLE
Fix for odd errors with other text modifiers

### DIFF
--- a/lua/easychat/modules/client/darkrp.lua
+++ b/lua/easychat/modules/client/darkrp.lua
@@ -19,7 +19,8 @@ hook.Add("ECPostInitialized", "EasyChatModuleDarkRP", function()
 
 		EasyChat.AddNameTags(ply, msg_components)
 
-		if prefix then
+		-- Check if prefix is a string, as some text modifiers can return odd things here.
+		if type(prefix) == "string" then
 			if col1 == team.GetColor(ply:Team()) then -- Just prettier
 				col1 = color_white
 			end


### PR DESCRIPTION
Sometimes other addons that hook PlayerSay and return modified strings break this easychat module.
Replacing 'if prefix then' with a string type check seems to fix this. (At least in my testing)