### PR TITLE
Twemoji: Replace Deprecated MaxCDN with JDecked Twemoji

### DIFF
--- a/lua/easychat/modules/client/twemojis.lua
+++ b/lua/easychat/modules/client/twemojis.lua
@@ -174,7 +174,7 @@ end, function(err)
 end)
 
 local function get_twemoji_url(name)
-	return ("https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/%s.png"):format(discord_lookup[name])
+	return ("https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/%s.png"):format(discord_lookup[name])
 end
 
 local function get_twemoji_url_codepoints(tbl)
@@ -183,7 +183,7 @@ local function get_twemoji_url_codepoints(tbl)
 		table.insert(formatted, ("%x"):format(num))
 	end
 
-	return ("https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/%s.png"):format(table.concat(formatted, "-"))
+	return ("https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/%s.png"):format(table.concat(formatted, "-"))
 end
 
 local function to_hex(str)

--- a/lua/easychat/modules/client/twemojis.lua
+++ b/lua/easychat/modules/client/twemojis.lua
@@ -174,7 +174,7 @@ end, function(err)
 end)
 
 local function get_twemoji_url(name)
-	return ("https://twemoji.maxcdn.com/v/latest/72x72/%s.png"):format(discord_lookup[name])
+	return ("https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/%s.png"):format(discord_lookup[name])
 end
 
 local function get_twemoji_url_codepoints(tbl)
@@ -183,7 +183,7 @@ local function get_twemoji_url_codepoints(tbl)
 		table.insert(formatted, ("%x"):format(num))
 	end
 
-	return ("https://twemoji.maxcdn.com/v/latest/72x72/%s.png"):format(table.concat(formatted, "-"))
+	return ("https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/%s.png"):format(table.concat(formatted, "-"))
 end
 
 local function to_hex(str)

--- a/lua/easychat/modules/client/twemojis.lua
+++ b/lua/easychat/modules/client/twemojis.lua
@@ -174,7 +174,7 @@ end, function(err)
 end)
 
 local function get_twemoji_url(name)
-	return ("https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/%s.png"):format(discord_lookup[name])
+	return ("https://jdecked.github.io/twemoji/v/latest/72x72/%s.png"):format(discord_lookup[name])
 end
 
 local function get_twemoji_url_codepoints(tbl)
@@ -183,7 +183,7 @@ local function get_twemoji_url_codepoints(tbl)
 		table.insert(formatted, ("%x"):format(num))
 	end
 
-	return ("https://cdn.jsdelivr.net/gh/jdecked/twemoji@latest/assets/72x72/%s.png"):format(table.concat(formatted, "-"))
+	return ("https://jdecked.github.io/twemoji/v/latest/72x72/%s.png"):format(table.concat(formatted, "-"))
 end
 
 local function to_hex(str)


### PR DESCRIPTION
https://github.com/twitter/twemoji/issues/580 states the usual cdn (MaxCDN) is no longer working, this replaces it to use cdnjs instead on the latest version (14.0.2).