### PR TITLE
Fix to Ranks and update to DarkRP

### DIFF
--- a/lua/easychat/client/settings.lua
+++ b/lua/easychat/client/settings.lua
@@ -885,10 +885,6 @@ local function create_default_settings()
 		end
 
 		local function setup_rank(usergroup)
-			usergroup = usergroup or "user"
-
-			-- sanity check to see if wanted usergroup actually exists
-			if usergroup and not EasyChat.Config.UserGroups[usergroup] then return end
 
 			local frame = EasyChat.CreateFrame()
 			frame:SetSize(400, 400)

--- a/lua/easychat/modules/client/darkrp.lua
+++ b/lua/easychat/modules/client/darkrp.lua
@@ -1,4 +1,4 @@
-if not DarkRP then return "DarkRP Compat" end
+if not DarkRP or DarkRP.MetaName ~= "DarkRP" then return "DarkRP Compat" end
 
 local color_white = color_white
 

--- a/lua/easychat/modules/client/darkrp.lua
+++ b/lua/easychat/modules/client/darkrp.lua
@@ -1,4 +1,4 @@
-if gmod.GetGamemode().Name ~= "DarkRP" then return "DarkRP Compat" end
+if not DarkRP then return "DarkRP Compat" end
 
 local color_white = color_white
 


### PR DESCRIPTION
Two small simple fixes.

There was an issue where the user is unable to Setup a new Rank.

And and updated the DarkRP to instead of checking for the gamemode name, to check for the global DarkRP variable. To allow for DarkRP derived gamemodes to be automatically detected.