### PR TITLE
Fix: message preservation for legacy text box and history

### DIFF
--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -91,6 +91,19 @@ function PANEL:Init()
 
 	self:AddInternalCallback("OnArrowDown", function(caret_pos)
 		self.CaretPos = caret_pos
+
+		if EC_PRESERVE_MESSAGE_IN_PROGRESS:GetBool() and self.HistoryPos == 0 then
+			local textInProgress = self:GetTextInProgress()
+
+			if textInProgress and #textInProgress ~= 0 and self:GetText() == textInProgress then
+				-- clear text entry from the message in progress
+				self:SetText("")
+				self:OnChange()
+				self:OnValueChange("")
+				return
+			end
+		end
+
 		self.HistoryPos = self.HistoryPos + 1
 		self:UpdateFromHistory()
 	end)

--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -8,12 +8,6 @@ local PANEL = {
 
 local EC_PRESERVE_MESSAGE_IN_PROGRESS = GetConVar("easychat_preserve_message_in_progress")
 
-cvars.AddChangeCallback("easychat_preserve_message_in_progress", function()
-	if not EC_PRESERVE_MESSAGE_IN_PROGRESS:GetBool() then
-		PANEL.ValueInProgress = ""
-	end
-end, "clear_value_in_progress_on_disable")
-
 function PANEL:Init()
 	self:SetFocusTopLevel(true)
 	self:SetKeyboardInputEnabled(true)
@@ -82,11 +76,11 @@ function PANEL:Init()
 		if EC_PRESERVE_MESSAGE_IN_PROGRESS:GetBool() and self.HistoryPos == 0 then
 			local textInProgress = self:GetTextInProgress()
 
-			if textInProgress ~= self:GetText() and textInProgress ~= self.History[#self.History] then
+			if textInProgress and #textInProgress ~= 0 and self:GetText() ~= textInProgress then
 				-- bring back message in progress
-				self:SetText(self:GetTextInProgress())
+				self:SetText(textInProgress)
 				self:OnChange()
-				self:OnValueChange(self:GetTextInProgress())
+				self:OnValueChange(textInProgress)
 				return
 			end
 		end
@@ -106,6 +100,8 @@ function PANEL:Init()
 	end)
 
 	self:AddInternalCallback("OnEnter", function(caret_pos)
+		if input.IsKeyDown(KEY_LSHIFT) or input.IsKeyDown(KEY_RSHIFT) then return end
+
 		self.CaretPos = caret_pos
 		self:AddHistory(self:GetText())
 		self.HistoryPos = 0
@@ -301,11 +297,6 @@ function PANEL:GetText()
 end
 PANEL.GetValue = PANEL.GetText
 
-function PANEL:GetTextInProgress()
-	return self.ValueInProgress
-end
-PANEL.GetValueInProgress = PANEL.GetTextInProgress
-
 function PANEL:SetText(text)
 	text = isstring(text) and text or ""
 
@@ -319,6 +310,16 @@ function PANEL:SetValue(text)
 	self:OnChange()
 	self:OnValueChange(text)
 end
+
+function PANEL:GetTextInProgress()
+	return self.ValueInProgress
+end
+PANEL.GetValueInProgress = PANEL.GetTextInProgress
+
+function PANEL:SetTextInProgress(text)
+	self.ValueInProgress = text
+end
+PANEL.SetValueInProgress = PANEL.SetTextInProgress
 
 -- this cannot work due to the limitations of the lua -> js interop
 function PANEL:AllowInput(last_char) end

--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -1742,9 +1742,29 @@ if CLIENT then
 		if input.IsKeyDown(KEY_LSHIFT) then return end
 
 		if key_code == KEY_UP then
+			if EC_PRESERVE_MESSAGE_IN_PROGRESS:GetBool() and text_entry.HistoryPos == 0 then
+				local textInProgress = text_entry:GetTextInProgress()
+
+				if textInProgress and #textInProgress ~= 0 and text_entry:GetText() ~= textInProgress then
+					-- bring back message in progress
+					text_entry:SetText(textInProgress)
+					return
+				end
+			end
+
 			text_entry.HistoryPos = text_entry.HistoryPos - 1
 			text_entry:UpdateFromHistory()
 		elseif key_code == KEY_DOWN then
+			if EC_PRESERVE_MESSAGE_IN_PROGRESS:GetBool() and text_entry.HistoryPos == 0 then
+				local textInProgress = text_entry:GetTextInProgress()
+
+				if textInProgress and #textInProgress ~= 0 and text_entry:GetText() == textInProgress then
+					-- clear text entry from the message in progress
+					text_entry:SetText("")
+					return
+				end
+			end
+
 			text_entry.HistoryPos = text_entry.HistoryPos + 1
 			text_entry:UpdateFromHistory()
 		end

--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -825,6 +825,10 @@ if CLIENT then
 		EasyChat.GUI.TextEntry:SetText("")
 		EasyChat.GUI.TextEntry.HistoryPos = 0 -- reset history also
 
+		if not EC_PRESERVE_MESSAGE_IN_PROGRESS:GetBool() then
+			EasyChat.GUI.TextEntry:SetTextInProgress("")
+		end
+
 		gui.EnableScreenClicker(false)
 		hook.Run("ChatTextChanged", "")
 		hook.Run("FinishChat")
@@ -2278,6 +2282,7 @@ if CLIENT then
 		function EasyChat.GUI.TextEntry:OnEnter()
 			if input.IsKeyDown(KEY_LSHIFT) or input.IsKeyDown(KEY_RSHIFT) then return end
 
+			self:SetTextInProgress("")
 			local msg = EasyChat.ExtendedStringTrim(self:GetText())
 			self:SetText(msg)
 


### PR DESCRIPTION
- add support for message preservation for legacy text box
- weird up arrow behavior
- prevent saving history on shift+enter