### PR TITLE
CEF-based autocomplete for consistent, smooth text visuals

### DIFF
--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -90,7 +90,7 @@ function PANEL:Init()
 				autocorrect="off"
 				autocapitalize="off"
 				spellcheck="false"
-			/>
+			></textarea>
 			<div id="completion">
 				<span id="completion-hidden" style="color: transparent"></span><span id="completion-placeholder"></span>
 			</div>

--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -334,7 +334,6 @@ function PANEL:Init()
 			size = EC_FONT_SIZE:GetInt(),
 		})
 	end
-
 	cvars.RemoveChangeCallback("easychat_font_size", "TextEntryX")
 	cvars.AddChangeCallback("easychat_font_size", function() setFontSize() end, "TextEntryX")
 	setFontSize(true)
@@ -514,11 +513,11 @@ local function blink(w, h)
 		local text_x, text_y = w / 2 - text_w / 2, -(text_h + 2)
 
 		surface_DisableClipping(true)
-		surface_DrawRect(text_x - 2, text_y - 2, text_w + 4, text_h + 4)
+			surface_DrawRect(text_x - 2, text_y - 2, text_w + 4, text_h + 4)
 
-		surface_SetTextPos(text_x, text_y)
-		surface_SetTextColor(color_white)
-		surface_DrawText(blink_text)
+			surface_SetTextPos(text_x, text_y)
+			surface_SetTextColor(color_white)
+			surface_DrawText(blink_text)
 		surface_DisableClipping(false)
 	end
 end

--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -41,6 +41,8 @@ function PANEL:Init()
 					border: none;
 					padding-left: 5px;
 					padding-top: 4px;
+					padding-bottom: 2px;
+					padding-right: 2px;
 					font-family: 'Roboto', sans-serif;
 					resize: none;
 					text-shadow: ]] .. (EasyChat.UseDermaSkin and "none;" or [[-1px 1px 2px #000,
@@ -59,6 +61,8 @@ function PANEL:Init()
 					border: none;
 					padding-left: 5px;
 					padding-top: 4px;
+					padding-bottom: 2px;
+					padding-right: 2px;
 					font-family: 'Roboto', sans-serif;
 					vertical-align: top;
 					z-index: -1;
@@ -80,6 +84,7 @@ function PANEL:Init()
 				}
 				#completion-placeholder {
 					background: green;
+					color: white;
 				}
 
 				*/
@@ -201,9 +206,6 @@ function PANEL:Init()
 			} else {
 				COMPLETION_PLACEHOLDER.textContent = ' ' + ['<<', completionText, '>>'].join(' ');
 			}
-			// follow the textarea's inner scrolling, as it gets bigger or smaller
-			// this should not break anything visually...
-			COMPLETION.style.top = (-TEXT_ENTRY.scrollTop) + "px";
 		}
 		const RESET_COMPLETION_TEXT = () => {
 			COMPLETION_HIDDEN.textContent = '';
@@ -215,11 +217,16 @@ function PANEL:Init()
 				COMPLETION_PLACEHOLDER.textContent = '';
 			}
 		}
+		TEXT_ENTRY.addEventListener("scroll", (ev) => {
+			// follow the textarea's inner scrolling, as it gets bigger or smaller
+			// this should not break anything visually...
+			COMPLETION.style.top = (-TEXT_ENTRY.scrollTop) + "px";
+		});
+
 		const SET_TEXT_ENTRY = (text) => {
 			TEXT_ENTRY.value = text;
 			RESET_COMPLETION_TEXT();
 		}
-
 		TEXT_ENTRY.addEventListener("contextmenu", (_) => TextEntryX.OnRightClick());
 		TEXT_ENTRY.addEventListener("paste", (ev) => {
 			if (!ev.clipboardData && !window.clipboardData) return;

--- a/lua/easychat/client/vgui/textentryx.lua
+++ b/lua/easychat/client/vgui/textentryx.lua
@@ -7,6 +7,7 @@ local PANEL = {
 }
 
 local EC_PRESERVE_MESSAGE_IN_PROGRESS = GetConVar("easychat_preserve_message_in_progress")
+local EC_FONT_SIZE = GetConVar("easychat_font_size")
 
 function PANEL:Init()
 	self:SetFocusTopLevel(true)
@@ -44,20 +45,57 @@ function PANEL:Init()
 					resize: none;
 					text-shadow: ]] .. (EasyChat.UseDermaSkin and "none;" or [[-1px 1px 2px #000,
 						1px 1px 2px #000,
-					   	1px -1px 2px #000;
-						-1px -1px 2px #000;]])
-					.. [[
+					  1px -1px 2px #000,
+						-1px -1px 2px #000;]]) .. [[
+					vertical-align: top;
+					z-index: 0;
 				}
+				#completion {
+					position: absolute;
+					top: 0;
+					left: 0;
+					right: 0;
+					bottom: 0;
+					border: none;
+					padding-left: 5px;
+					padding-top: 4px;
+					font-family: 'Roboto', sans-serif;
+					vertical-align: top;
+					z-index: -1;
+					pointer-events: none;
+					user-select: none;
+				}
+				#completion span {
+					white-space: pre-wrap;
+				}
+
+				/*
+					debugging
+					feel free to make completion-hidden a different color instead of just transparent too
+
+				#completion {
+					opacity: 1;
+					background: rgba(255, 0, 0, 0.5);
+					z-index: 10;
+				}
+				#completion-placeholder {
+					background: green;
+				}
+
+				*/
 			</style>
 			<textarea
 				id="text-entry"
 				autocomplete="off"
 				autocorrect="off"
 				autocapitalize="off"
-				spellcheck="false" />
+				spellcheck="false"
+			/>
+			<div id="completion">
+				<span id="completion-hidden" style="color: transparent"></span><span id="completion-placeholder"></span>
+			</div>
 		</body>
 	</html>]])
-
 	self:AddInternalCallback("OnChange", function(value, caret_pos)
 		self.CurrentValue = value
 		self.CaretPos = caret_pos
@@ -146,11 +184,42 @@ function PANEL:Init()
 	self:AddInternalCallback("GetPlaceholderText", function()
 		return self.PlaceholderText or ""
 	end)
-
+	self:AddInternalCallback("GetCompletionText", function()
+		return self.CompletionText or ""
+	end)
 	self:AddInternalCallback("Debug", print)
-
 	self:QueueJavascript([[
 		const TEXT_ENTRY = document.getElementById("text-entry");
+		const COMPLETION = document.getElementById("completion");
+		const COMPLETION_HIDDEN = document.getElementById("completion-hidden");
+		const COMPLETION_PLACEHOLDER = document.getElementById("completion-placeholder");
+
+		const SET_COMPLETION_TEXT = (completionText, text) => {
+			COMPLETION_HIDDEN.textContent = text;
+			if (completionText.search(text) == 0) {
+				COMPLETION_PLACEHOLDER.textContent = completionText.slice(text.length);
+			} else {
+				COMPLETION_PLACEHOLDER.textContent = ' ' + ['<<', completionText, '>>'].join(' ');
+			}
+			// follow the textarea's inner scrolling, as it gets bigger or smaller
+			// this should not break anything visually...
+			COMPLETION.style.top = (-TEXT_ENTRY.scrollTop) + "px";
+		}
+		const RESET_COMPLETION_TEXT = () => {
+			COMPLETION_HIDDEN.textContent = '';
+			if (TEXT_ENTRY.value == '') {
+				TextEntryX.GetPlaceholderText(placeholderText => {
+					COMPLETION_PLACEHOLDER.textContent = placeholderText;
+				});
+			} else {
+				COMPLETION_PLACEHOLDER.textContent = '';
+			}
+		}
+		const SET_TEXT_ENTRY = (text) => {
+			TEXT_ENTRY.value = text;
+			RESET_COMPLETION_TEXT();
+		}
+
 		TEXT_ENTRY.addEventListener("contextmenu", (_) => TextEntryX.OnRightClick());
 		TEXT_ENTRY.addEventListener("paste", (ev) => {
 			if (!ev.clipboardData && !window.clipboardData) return;
@@ -198,6 +267,18 @@ function PANEL:Init()
 					break;
 			}
 		});
+
+		TEXT_ENTRY.addEventListener("input", (ev) => {
+			const text = ev.target.value;
+			TextEntryX.GetCompletionText(completionText => {
+				if (!completionText) {
+					RESET_COMPLETION_TEXT();
+					return;
+				}
+
+				SET_COMPLETION_TEXT(completionText, text);
+			});
+		});
 	]])
 
 	local EC_NON_QWERTY = GetConVar("easychat_non_qwerty")
@@ -211,7 +292,7 @@ function PANEL:Init()
 
 		function insertAtCursor(text) {
 			const val = TEXT_ENTRY.value;
-			TEXT_ENTRY.value = val + text;
+			SET_TEXT_ENTRY(val + text);
 			TextEntryX.OnChange(TEXT_ENTRY.value, TEXT_ENTRY.selectionStart);
 		}
 
@@ -240,6 +321,23 @@ function PANEL:Init()
 		TEXT_ENTRY.click();
 		TEXT_ENTRY.focus();
 	]])
+
+	-- EC_FONT_SIZE
+	local setFontSize = function(init)
+		self:QueueJavascript([[
+			TEXT_ENTRY.style.fontSize = "]] .. tostring(EC_FONT_SIZE:GetInt() - 3) .. [[px";
+			COMPLETION.style.fontSize = "]] .. tostring(EC_FONT_SIZE:GetInt() - 3) .. [[px";
+		]])
+		if init then return end
+		surface.CreateFont("EasyChatCompletionFont", {
+			font = "Roboto",
+			size = EC_FONT_SIZE:GetInt(),
+		})
+	end
+
+	cvars.RemoveChangeCallback("easychat_font_size", "TextEntryX")
+	cvars.AddChangeCallback("easychat_font_size", function() setFontSize() end, "TextEntryX")
+	setFontSize(true)
 
 	local skin = self:GetSkin()
 	self:SetBackgroundColor(skin.colTextEntryBG)
@@ -315,7 +413,7 @@ function PANEL:SetText(text)
 
 	self.CurrentValue = text
 
-	self:QueueJavascript([[TextEntryX.GetCurrentValue(x => TEXT_ENTRY.value = x);]])
+	self:QueueJavascript([[TextEntryX.GetCurrentValue(x => SET_TEXT_ENTRY(x));]])
 end
 
 function PANEL:SetValue(text)
@@ -348,18 +446,11 @@ end
 
 function PANEL:SetPlaceholderText(text)
 	self.PlaceholderText = text
-
-	self:QueueJavascript([[TextEntryX.GetPlaceholderText(x => TEXT_ENTRY.placeholder = x);]])
 end
 
 function PANEL:SetPlaceholderColor(col)
 	self.PlaceholderColor = col
-	self:QueueJavascript([[{
-		const style = document.createElement("style");
-		style.type = "text/css";
-		style.innerHTML = "#text-entry::placeholder { color: ]] .. color_to_css(col)  .. [[; }";
-		document.getElementsByTagName("head")[0].appendChild(style);
-	}]])
+	self:QueueJavascript(([[COMPLETION.style.color = "%s"]]):format(color_to_css(col)))
 end
 
 function PANEL:SetCompletionText(text)
@@ -375,8 +466,8 @@ function PANEL:GetTextColor()
 end
 
 function PANEL:SetBackgroundColor(col)
-	self:QueueJavascript(([[TEXT_ENTRY.style.backgroundColor = "%s";]]):format(color_to_css(col)))
 	self.BackgroundColor = col
+	self:QueueJavascript(([[TEXT_ENTRY.style.backgroundColor = "%s";]]):format(color_to_css(col)))
 end
 
 function PANEL:GetBackgroundColor()
@@ -393,7 +484,7 @@ end
 
 surface.CreateFont("EasyChatCompletionFont", {
 	font = "Roboto",
-	size = 16,
+	size = EC_FONT_SIZE:GetInt(),
 })
 
 local surface_DisableClipping = _G.surface.DisableClipping
@@ -420,14 +511,14 @@ local function blink(w, h)
 	if blink_text then
 		surface_SetFont("EasyChatCompletionFont")
 		local text_w, text_h = surface_GetTextSize(blink_text)
-		local text_x, text_y = w / 2 - text_w / 2, - (text_h + 2)
+		local text_x, text_y = w / 2 - text_w / 2, -(text_h + 2)
 
 		surface_DisableClipping(true)
-			surface_DrawRect(text_x - 2, text_y - 2, text_w + 4, text_h + 4)
+		surface_DrawRect(text_x - 2, text_y - 2, text_w + 4, text_h + 4)
 
-			surface_SetTextPos(text_x, text_y)
-			surface_SetTextColor(color_white)
-			surface_DrawText(blink_text)
+		surface_SetTextPos(text_x, text_y)
+		surface_SetTextColor(color_white)
+		surface_DrawText(blink_text)
 		surface_DisableClipping(false)
 	end
 end
@@ -445,24 +536,6 @@ function PANEL:PaintOver(w, h)
 	if EasyChat.UseDermaskin then return end
 	surface_SetDrawColor(self.BorderColor)
 	surface_DrawOutlinedRect(0, 0, w, h)
-
-	if self.CompletionText then
-		surface_SetTextColor(self.PlaceholderColor)
-		surface_SetFont("EasyChatCompletionFont")
-		local cur_text_w = surface_GetTextSize(self.CurrentValue)
-		local start_pos, end_pos = string_find(self.CompletionText, self.CurrentValue, 1, true)
-		if start_pos == 1 then
-			local sub_completion = string_sub(self.CompletionText, end_pos + 1)
-			local _, completion_text_h = surface_GetTextSize(sub_completion)
-			surface_SetTextPos(cur_text_w + 3, h / 2 - completion_text_h / 2)
-			surface_DrawText(sub_completion)
-		else
-			local sub_completion = string_format("<< %s >>", self.CompletionText)
-			local _, completion_text_h = surface_GetTextSize(sub_completion)
-			surface_SetTextPos(cur_text_w + 15, h / 2 - completion_text_h / 2)
-			surface_DrawText(sub_completion)
-		end
-	end
 
 	blink(w, h)
 end


### PR DESCRIPTION
"type something..." is now in place of the autocomplete text when the input is empty

I've tried to test plenty and saw nothing wrong?

https://cdn.discordapp.com/attachments/1291060726303166545/1374133890788360283/gmod_2025-05-19_23-16-54_726.mp4?ex=682cf169&is=682b9fe9&hm=499a30057e804cf59d5fdb5dc0af935d03d5234f39abe8cd0d998cec7586de3a&