### PR TITLE
Allow one symbol nicks

### DIFF
--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -107,7 +107,7 @@ function EasyChat.IsStringEmpty(str, is_nick)
 	if #sanitized_str == 0 then return true end
 
 	-- if its a nick dont allow under 2 chars
-	if is_nick and utf8.len(sanitized_str) < 2 then
+	if is_nick and utf8.len(sanitized_str) < 1 then
 		return true
 	end
 

--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -106,7 +106,7 @@ function EasyChat.IsStringEmpty(str, is_nick)
 	local sanitized_str = EasyChat.ExtendedStringTrim(str, true)
 	if #sanitized_str == 0 then return true end
 
-	-- if its a nick dont allow under 2 chars
+	-- if its a nick dont allow under 1 char
 	if is_nick and utf8.len(sanitized_str) < 1 then
 		return true
 	end


### PR DESCRIPTION
Steam and chat can normally display such nicknames. Why replace them with NO NAME?