### PR TITLE
Disallow custom font in nicks

### DIFF
--- a/lua/easychat/chathud.lua
+++ b/lua/easychat/chathud.lua
@@ -398,6 +398,7 @@ chathud:RegisterPart("color", color_part)
 	Font changes.
 ]]-------------------------------------------------------------------------------
 local font_part = {
+	OkInNicks = false,
 	Usage = "<font=font_name>",
 	Examples = {
 		"<font=DermaLarge>I am big!"


### PR DESCRIPTION
Some players may set the font to unreadably small or super huge. I don't think it should be like that.