### PR TITLE
Add `is_local` to `player_say`

### DIFF
--- a/lua/easychat/networking.lua
+++ b/lua/easychat/networking.lua
@@ -100,6 +100,7 @@ if SERVER then
 			userid = IsValid(ply) and ply:UserID() or 0,
 			text = msg,
 			teamonly = is_team and 1 or 0,
+			is_local = is_local and 1 or 0
 		})
 
 		local filter = {}
@@ -440,6 +441,7 @@ if CLIENT then
 						userid = IsValid(ply) and ply:UserID() or 0,
 						text = msg,
 						teamonly = is_team and 1 or 0,
+						is_local = is_local and 1 or 0
 					})
 				end
 			end)
@@ -452,6 +454,7 @@ if CLIENT then
 				userid = IsValid(ply) and ply:UserID() or 0,
 				text = msg,
 				teamonly = is_team and 1 or 0,
+				is_local = is_local and 1 or 0
 			})
 		end
 	end


### PR DESCRIPTION
Allows you to determine whether a message is local in `player_say` gamevent
This is useful if you want to support both enabled and disabled easychat players