### PR TITLE
Clamp chathud bounds

### DIFF
--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -3167,4 +3167,3 @@ function EasyChat.Reload()
 end
 
 concommand.Add("easychat_reload", EasyChat.Reload)
-

--- a/lua/easychat/easychat.lua
+++ b/lua/easychat/easychat.lua
@@ -2958,7 +2958,12 @@ if CLIENT then
 			chathud_call = false
 
 			if EC_HUD_CUSTOM:GetBool() and should_draw then
+				local pos, size = chathud.Pos, chathud.Size
+				render.SetScissorRect(pos.X, pos.Y, pos.X + size.W, pos.Y + size.H, true)
+
 				chathud:Draw()
+
+				render.SetScissorRect(0, 0, 0, 0, false)
 			end
 		end)
 
@@ -3162,3 +3167,4 @@ function EasyChat.Reload()
 end
 
 concommand.Add("easychat_reload", EasyChat.Reload)
+


### PR DESCRIPTION
Without this, anyone can flood the player chat with a flood of messages or messages with bad formatting, this PR clamps the size of the ChatHUD to the size of the chat window

https://github.com/user-attachments/assets/2a6ef9e7-bf75-4c84-8c62-2de85ab971bb